### PR TITLE
Adding jsontokens to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "istanbul": "^0.4.0",
     "jsdom": "^9.2.0",
     "json-loader": "^0.5.4",
+    "jsontokens": "^0.7.4",
     "knox": "^0.9.2",
     "minimist": "^1.2.0",
     "mocha": "^2.5.3",


### PR DESCRIPTION
jsontokens is required by AuthModal.js, but was missing from package.json