### PR TITLE
v0.6 core auth

### DIFF
--- a/app/js/store/settings.js
+++ b/app/js/store/settings.js
@@ -9,7 +9,7 @@ const DEFAULT_API = {
   nameLookupUrl: 'http://localhost:6270/v1/names/{name}',
   searchUrl: 'https://api.blockstack.com/v1/search?query={query}',
   registerUrl: 'http://localhost:6270/v1/names',
-  addressLookupUrl: 'http://localhost:6270/v1/addresses/{address}',
+  addressLookupUrl: 'http://localhost:6270/v1/addresses/bitcoin/{address}',
   addressBalanceUrl: 'https://explorer.blockstack.org/insight-api/addr/{address}/?noTxList=1',
   utxoUrl: 'https://explorer.blockstack.org/insight-api/addr/{address}/utxo',
   broadcastTransactionUrl: 'https://explorer.blockstack.org/insight-api/tx/send',
@@ -27,7 +27,9 @@ const DEFAULT_API = {
   s3ApiKey: '',
   s3ApiSecret: '',
   s3Bucket: '',
-  dropboxAccessToken: null
+  dropboxAccessToken: null,
+  coreHost: 'localhost',
+  corePort: 6270
 }
 
 function updateApi(api) {

--- a/app/js/utils/api-utils.js
+++ b/app/js/utils/api-utils.js
@@ -14,7 +14,7 @@ export function getNamesOwned(address, addressLookupUrl, callback) {
 }
 
 export function authorizationHeaderValue() {
-  return `basic ${CORE_API_PASSWORD}`
+  return `bearer ${CORE_API_PASSWORD}`
 }
 
 /*


### PR DESCRIPTION
This PR adds support for generating Core session tokens once the application authentication request has been approved.  The core session token gets sent to the app as part of an auth response.

This requires the `develop-core-auth` branch of `blockstack.js` to work.